### PR TITLE
Fix 2 Cross-Site Scripting Security Vulnerabilities

### DIFF
--- a/gestorpsi/contact/views.py
+++ b/gestorpsi/contact/views.py
@@ -14,7 +14,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 """
 
-from django.utils import simplejson
+from django.utils import simplejson, html
 from django.shortcuts import render_to_response, get_object_or_404
 from django.http import HttpResponse, HttpResponseRedirect, Http404
 from django.template import RequestContext
@@ -332,6 +332,7 @@ def save_mini(request):
             obj.contact_owner = user.get_profile().person
             obj.save()
             r = u"%s|%s|%s" % (False, obj.id, obj.name)
+            r = html.escape(r)
 
     return HttpResponse(r)
 

--- a/gestorpsi/report/views.py
+++ b/gestorpsi/report/views.py
@@ -24,6 +24,7 @@ from django.utils.translation import ugettext as _
 from django.shortcuts import get_object_or_404
 from django.template.defaultfilters import slugify
 from django.utils import simplejson
+from django.utils.html import escape
 from django.db.models import Q
 
 from gestorpsi.admission.models import AdmissionReferral
@@ -184,7 +185,7 @@ def report_save(request, form_class=None, view=None, template='report/report_sav
 
         if save_form.is_valid():
             data = save_form.save(request.user, request.user.get_profile().org_active)
-            return HttpResponse(data.label)
+            return HttpResponse(escape(data.label))
         else:
             raise Exception(_('Error to save register'))
 


### PR DESCRIPTION
Hello,

I noticed 2 Cross-Site Scripting [(XSS)](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)) vulnerabilities in contact/views.py and report/views.py.

The one in contact/views.py can be triggered by executing a POST request to `/save_mini` with `label` HTTP parameter set to something like `<script>evil_code</script>`. If any legit user can be tricked into executing such a request, then attackers can achieve remote code execution in user's browser, which is a serious security issue.

Similarly, the XSS in report/views.py can be exploited by setting the `label` parameter to same payload.

Please consider my proposed fixes.

I found the bug while testing DeepCode’s AI Code Review. The tool can help you automate the process of finding such (and many other types of) bugs. You can sign-up your repo (free for Open Source) to receive notifications whenever new bugs are detected. You can give it a try [here](https://deepcode.ai/app/gh/review?utm_source=github_python&utm_campaign=gestorpsi_gestorpsi_XSS).

Any feedback is more than welcome at chibo@deepcode.ai.

Cheers, Victor.